### PR TITLE
[WIP] JWTを使って認証するぞ

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,8 @@ gem 'carrierwave', '~> 0.10.0'
 gem 'mini_magick', '~> 4.2.7'
 gem 'fog', '~> 1.23'
 
+gem 'jwt', '~> 1.5'
+
 group :development, :test do
   # Use sqlite3 as the database for Active Record
   gem 'sqlite3', '~> 1.3.9'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -206,6 +206,7 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (1.8.3)
+    jwt (1.5.1)
     kgio (2.9.3)
     listen (2.10.1)
       celluloid (~> 0.16.0)
@@ -349,6 +350,7 @@ DEPENDENCIES
   i18n-debug (~> 1.0)
   jbuilder (~> 2.2)
   jquery-rails (~> 4.0.4)
+  jwt (~> 1.5)
   mini_backtrace (~> 0.1.3)
   mini_magick (~> 4.2.7)
   minitest-reporters (~> 1.0.5)
@@ -365,3 +367,6 @@ DEPENDENCIES
   web-console (~> 2.1)
   will-paginate-i18n (~> 0.1.15)
   will_paginate (~> 3.0.7)
+
+BUNDLED WITH
+   1.10.6

--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -9,7 +9,7 @@ class Api::ApplicationController < ActionController::Base
   def logged_in_user
     unless logged_in?
       @messages = ["Unauthorized"]
-      render "api/shared/error_messages", status: :unauthorized
+      render "api/shared/error_messages.json", status: :unauthorized
     end
   end
 end

--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -8,8 +8,11 @@ class Api::ApplicationController < ActionController::Base
   # Confirms a logged-in user
   def logged_in_user
     unless logged_in?
-      @messages = ["Unauthorized"]
-      render "api/shared/error_messages.json", status: :unauthorized
+      render_errors ["Unauthorized"], status: :unauthorized
     end
+  end
+
+  def render_errors(error_messages, options)
+    render options.merge!(json: {"errors" => error_messages})
   end
 end

--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -1,0 +1,15 @@
+class Api::ApplicationController < ActionController::Base
+  # Prevent CSRF attacks by raising an exception.
+  # For APIs, you may want to use :null_session instead.
+  protect_from_forgery with: :null_session
+
+  include SessionsHelper
+
+  # Confirms a logged-in user
+  def logged_in_user
+    unless logged_in?
+      @messages = ["Unauthorized"]
+      render "api/shared/error_messages", status: :unauthorized
+    end
+  end
+end

--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -13,6 +13,6 @@ class Api::ApplicationController < ActionController::Base
   end
 
   def render_errors(error_messages, options)
-    render options.merge!(json: {"errors" => error_messages})
+    render options.merge(json: {"errors" => error_messages})
   end
 end

--- a/app/controllers/api/feed_controller.rb
+++ b/app/controllers/api/feed_controller.rb
@@ -1,0 +1,7 @@
+class Api::FeedController < Api::ApplicationController
+  before_action :logged_in_user, only: [:index]
+
+  def index
+    render json: current_user.feed
+  end
+end

--- a/app/controllers/api/microposts_controller.rb
+++ b/app/controllers/api/microposts_controller.rb
@@ -1,6 +1,6 @@
 class Api::MicropostsController < Api::ApplicationController
   before_action :logged_in_user, only: [:create, :destroy]
-  before_action :correct_user, only: :destroy
+  before_action :correct_user,   only: :destroy
 
   def create
     @micropost = current_user.microposts.build(micropost_params)

--- a/app/controllers/api/microposts_controller.rb
+++ b/app/controllers/api/microposts_controller.rb
@@ -7,8 +7,7 @@ class Api::MicropostsController < Api::ApplicationController
     if @micropost.save
       render json: @micropost, status: :created
     else
-      @messages = @micropost.errors.full_messages
-      render "api/shared/error_messages.json", status: :unprocessable_entity
+      render_errors @micropost.errors.full_messages, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/api/microposts_controller.rb
+++ b/app/controllers/api/microposts_controller.rb
@@ -1,0 +1,30 @@
+class Api::MicropostsController < Api::ApplicationController
+  before_action :logged_in_user, only: [:create, :destroy]
+  before_action :correct_user, only: :destroy
+
+  def create
+    @micropost = current_user.microposts.build(micropost_params)
+    if @micropost.save
+      render json: @micropost, status: :created
+    else
+      @messages = @micropost.errors.full_messages
+      render "api/shared/error_messages.json", status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @micropost.destroy
+    render json: "", status: :accepted
+  end
+
+  private
+
+  def micropost_params
+    params.require(:micropost).permit(:content, :picture)
+  end
+
+  def correct_user
+    @micropost = current_user.microposts.find_by(id: params[:id])
+    redirect_to root_url unless @micropost
+  end
+end

--- a/app/controllers/api/microposts_controller.rb
+++ b/app/controllers/api/microposts_controller.rb
@@ -24,6 +24,6 @@ class Api::MicropostsController < Api::ApplicationController
 
   def correct_user
     @micropost = current_user.microposts.find_by(id: params[:id])
-    redirect_to root_url unless @micropost
+    render json: "", status: :forbidden unless @micropost
   end
 end

--- a/app/controllers/api/password_resets_controller.rb
+++ b/app/controllers/api/password_resets_controller.rb
@@ -1,0 +1,49 @@
+class Api::PasswordResetsController < Api::ApplicationController
+  before_action :get_user,         only: [:update]
+  before_action :valid_user,       only: [:update]
+  before_action :check_expiration, only: [:update]
+
+  def create
+    @user = User.find_by(email: params[:password_reset][:email].downcase)
+    if @user
+      @user.create_reset_digest
+      @user.send_password_reset_email
+      render json: "", status: :created
+    else
+      render_errors ["Email address not found"], status: :unprocessable_entity
+    end
+  end
+
+  def update
+    if params[:user][:password].blank?
+      render_errors ["Password can't be blank"], status: :unprocessable_entity
+    elsif @user.update(user_params)
+      log_in @user
+      render json: "", status: :accepted
+    else
+      render json: "", status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:password, :password_confirmation)
+  end
+
+  def get_user
+    @user = User.find_by(email: params[:email])
+  end
+
+  def valid_user
+    unless @user and @user.activated? and @user.authenticated?(:reset, params[:id])
+      redirect_to root_url
+    end
+  end
+
+  def check_expiration
+    if @user.password_reset_expired?
+      render_errors ["Password reset has expired"], status: :bad_request
+    end
+  end
+end

--- a/app/controllers/api/password_resets_controller.rb
+++ b/app/controllers/api/password_resets_controller.rb
@@ -21,7 +21,7 @@ class Api::PasswordResetsController < Api::ApplicationController
       log_in @user
       render json: "", status: :accepted
     else
-      render json: "", status: :unprocessable_entity
+      render_errors @user.errors.full_messages, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/api/sessions_controller.rb
+++ b/app/controllers/api/sessions_controller.rb
@@ -1,0 +1,24 @@
+class Api::SessionsController < Api::ApplicationController
+
+  def create
+    @user = User.find_by(email: params[:session][:email].downcase)
+    if @user && @user.authenticate(params[:session][:password])
+      if @user.activated?
+        log_in @user
+        remember @user
+
+        render json: "", status: :created
+      else
+        message = "Account not activated. Check your email for the activation link."
+        render_errors [message], status: :forbidden
+      end
+    else
+      render_errors ["Invalid email or password"], status: :unauthorized
+    end
+  end
+
+  def destroy
+    log_out if logged_in?
+    render json: "", status: :accepted
+  end
+end

--- a/app/views/api/shared/error_messages.json.jbuilder
+++ b/app/views/api/shared/error_messages.json.jbuilder
@@ -1,0 +1,1 @@
+json.errors @messages

--- a/app/views/api/shared/error_messages.json.jbuilder
+++ b/app/views/api/shared/error_messages.json.jbuilder
@@ -1,1 +1,0 @@
-json.errors @messages

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
   namespace :api, defaults: {format: 'json'} do
     post 'login' => 'sessions#create'
     delete 'logout' => 'sessions#destroy'
+    get 'feed' => 'feed#index'
     resources :users do
       member do
         get :following, :followers

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,19 @@ Rails.application.routes.draw do
   resources :microposts, only: [:create, :destroy]
   resources :relationships, only: [:create, :destroy]
 
+  namespace :api, {format: 'json'} do
+    post 'login' => 'sessions#create'
+    delete 'logout' => 'sessions#destroy'
+    resources :users do
+      member do
+        get :following, :followers
+      end
+    end
+    resources :password_resets, only: [:create, :update]
+    resources :microposts, only: [:create, :destroy]
+    resources :relationships, only: [:create, :destroy]
+  end
+
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,7 @@ Rails.application.routes.draw do
   resources :microposts, only: [:create, :destroy]
   resources :relationships, only: [:create, :destroy]
 
-  namespace :api, {format: 'json'} do
+  namespace :api, defaults: {format: 'json'} do
     post 'login' => 'sessions#create'
     delete 'logout' => 'sessions#destroy'
     resources :users do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,11 +23,12 @@ Rails.application.routes.draw do
     resources :users do
       member do
         get :following, :followers
+        post   'follow' => 'users#follow'
+        delete 'follow' => 'users#unfollow'
       end
     end
     resources :password_resets, only: [:create, :update]
     resources :microposts, only: [:create, :destroy]
-    resources :relationships, only: [:create, :destroy]
   end
 
   # The priority is based upon order of creation: first created -> highest priority.

--- a/test/controllers/api/feed_controller_test.rb
+++ b/test/controllers/api/feed_controller_test.rb
@@ -1,0 +1,22 @@
+require 'test_helper'
+
+class Api::FeedControllerTest < ActionController::TestCase
+
+  def setup
+    @user = users(:michael)
+  end
+
+  test 'should return micropost feed as json' do
+    log_in_as(@user)
+    get :index
+
+    assert_equal 200, response.status
+    assert_equal @user.feed.to_json, response.body
+  end
+
+  test 'should return 402 if user is not logged in' do
+    get :index
+
+    assert 402, response.status
+  end
+end

--- a/test/controllers/api/microposts_controller_test.rb
+++ b/test/controllers/api/microposts_controller_test.rb
@@ -46,4 +46,12 @@ class Api::MicropostsControllerTest < ActionController::TestCase
     assert_equal 401, response.status
     assert json["errors"].member? "Unauthorized"
   end
+
+  test 'should return 403 if current_user is not the owner' do
+    other = users(:archer)
+    log_in_as(other)
+    delete :destroy, id: @micropost
+
+    assert_equal 403, response.status
+  end
 end

--- a/test/controllers/api/microposts_controller_test.rb
+++ b/test/controllers/api/microposts_controller_test.rb
@@ -11,7 +11,7 @@ class Api::MicropostsControllerTest < ActionController::TestCase
     log_in_as(@user)
     post :create, micropost: {content: "Lorem ipsum"}
 
-    p json = JSON.parse(response.body)
+    json = JSON.parse(response.body)
 
     assert_equal 201, response.status
 

--- a/test/controllers/api/microposts_controller_test.rb
+++ b/test/controllers/api/microposts_controller_test.rb
@@ -1,0 +1,49 @@
+require 'test_helper'
+
+class Api::MicropostsControllerTest < ActionController::TestCase
+
+  def setup
+    @user = users(:michael)
+    @micropost = microposts(:orange)
+  end
+
+  test 'should return created micropost as json' do
+    log_in_as(@user)
+    post :create, micropost: {content: "Lorem ipsum"}
+
+    p json = JSON.parse(response.body)
+
+    assert_equal 201, response.status
+
+    assert_equal "Lorem ipsum", json["content"]
+    assert_equal @user.id, json["user_id"]
+    assert_not_nil json["created_at"]
+    assert_not_nil json["updated_at"]
+  end
+
+  test 'should return errors when params are invalid' do
+    log_in_as(@user)
+    post :create, micropost: {content: ""}
+
+    json = JSON.parse(response.body)
+
+    assert_equal 422, response.status
+    assert json["errors"].member? "Content can't be blank"
+  end
+
+  test 'should return 202 when deleted the micropost' do
+    log_in_as(@user)
+    delete :destroy, id: @micropost
+
+    assert_equal 202, response.status
+  end
+
+  test 'should return 401 if user was not logged in' do
+    post :create, micropost: {content: "Lorem inpsum"}
+
+    json = JSON.parse(response.body)
+
+    assert_equal 401, response.status
+    assert json["errors"].member? "Unauthorized"
+  end
+end

--- a/test/integration/api/password_resets_test.rb
+++ b/test/integration/api/password_resets_test.rb
@@ -28,6 +28,20 @@ class Api::PasswordResetsTest < ActionDispatch::IntegrationTest
     assert_equal 422, response.status
   end
 
+  test "should return 422 if given password didn't pass the validations" do
+    post api_password_resets_path, password_reset: {email: @user.email}
+    user = assigns(:user)
+
+    patch api_password_reset_path(user.reset_token),
+          email: user.email,
+          user: {password: 'abc', password_confirmation: 'abc'}
+
+    json = JSON.parse(response.body)
+
+    assert_equal 422, response.status
+    assert json["errors"].any? {|msg| msg =~ /too short/i}
+  end
+
   test 'should return 422 if confirmation did not match on reset' do
     post api_password_resets_path, password_reset: {email: @user.email}
     user = assigns(:user)

--- a/test/integration/api/password_resets_test.rb
+++ b/test/integration/api/password_resets_test.rb
@@ -6,7 +6,7 @@ class Api::PasswordResetsTest < ActionDispatch::IntegrationTest
     @user = users(:michael)
   end
 
-  test 'should return 422 when password was invalid' do
+  test 'should return 422 when email was invalid' do
     post api_password_resets_path, password_reset: {email: 'invaid'}
     assert_equal 422, response.status
   end

--- a/test/integration/api/password_resets_test.rb
+++ b/test/integration/api/password_resets_test.rb
@@ -1,0 +1,63 @@
+require 'test_helper'
+
+class Api::PasswordResetsTest < ActionDispatch::IntegrationTest
+  def setup
+    ActionMailer::Base.deliveries.clear
+    @user = users(:michael)
+  end
+
+  test 'should return 422 when password was invalid' do
+    post api_password_resets_path, password_reset: {email: 'invaid'}
+    assert_equal 422, response.status
+  end
+
+  test 'should return 201 when email was valid' do
+    post api_password_resets_path, password_reset: {email: @user.email}
+    assert_not_equal @user.reset_digest, @user.reload.reset_digest
+    assert_equal 1, ActionMailer::Base.deliveries.size
+    assert_equal 201, response.status
+  end
+
+  test 'should return 422 if user resets password with blank string' do
+    post api_password_resets_path, password_reset: {email: @user.email}
+    user = assigns(:user)
+
+    patch api_password_reset_path(user.reset_token),
+          email: user.email,
+          user: {password: '', password_confirmation: ''}
+    assert_equal 422, response.status
+  end
+
+  test 'should return 422 if confirmation did not match on reset' do
+    post api_password_resets_path, password_reset: {email: @user.email}
+    user = assigns(:user)
+
+    patch api_password_reset_path(user.reset_token),
+          email: user.email,
+          user: {password: 'foobaz', password_confirmation: 'barquux'}
+    assert_equal 422, response.status
+  end
+
+  test 'should make the user login if everything is ok' do
+    post api_password_resets_path, password_reset: {email: @user.email}
+    user = assigns(:user)
+
+    patch api_password_reset_path(user.reset_token),
+          email: user.email,
+          user: {password: 'foobar', password_confirmation: 'foobar'}
+    assert is_logged_in?, 'User should now be logged in'
+    assert @user.reload.authenticate('foobar'), 'User should be able to login with the new password'
+  end
+
+  test 'expired token' do
+    post api_password_resets_path, password_reset: { email: @user.email }
+
+    @user = assigns(:user)
+    @user.update(reset_sent_at: 3.hours.ago)
+
+    patch api_password_reset_path(@user.reset_token),
+          email: @user.email,
+          user: { password: 'foobar', password_confirmation: 'foobar' }
+    assert 201, response.status
+  end
+end

--- a/test/integration/api/users_login_test.rb
+++ b/test/integration/api/users_login_test.rb
@@ -1,0 +1,55 @@
+require 'test_helper'
+
+class Api::UserLoginTest < ActionDispatch::IntegrationTest
+
+  def setup
+    @user = users(:michael)
+  end
+
+  test 'should return 401 when given information is invalid' do
+    post api_login_path, session: {email: '', password: ''}
+
+    assert_equal 401, response.status
+  end
+
+  test 'login with valid information followed by logout' do
+    delete api_logout_path
+    post api_login_path, session: {email: @user.email, password: 'password'}
+
+    assert_equal 201, response.status
+    assert_not_empty cookies["user_id"]
+    assert_not_empty cookies["remember_token"]
+
+    delete api_logout_path
+
+    assert_equal 202, response.status
+
+    assert_empty cookies["user_id"]
+    assert_empty cookies["remember_token"]
+  end
+
+  test 'logout twice affects nothing' do
+    delete api_logout_path
+
+    assert_equal 202, response.status
+    assert_not is_logged_in?
+
+    delete api_logout_path
+
+    assert_equal 202, response.status
+    assert_not is_logged_in?
+  end
+
+  test "token should be remembered regardless of the remember_me parameter" do
+    session_params = {email: @user.email, password: 'password'}
+
+    post api_login_path, session: session_params.merge({remember_me: '1'})
+    assert_equal cookies['remember_token'], assigns(:user).remember_token
+
+    post api_login_path, session: session_params.merge({remember_me: '0'})
+    assert_equal cookies['remember_token'], assigns(:user).remember_token
+
+    post api_login_path, session: session_params.merge({remember_me: '0'})
+    assert_equal cookies['remember_token'], assigns(:user).remember_token
+  end
+end


### PR DESCRIPTION
### 概要

Web版ではcookieを読んで`current_user`をセットしていましたが、API版ではログイン時にトークンを渡して、以後のリクエストにそれを付けてもらうようにします。

トークンは`remember_token`と`user_id`を使い、モダンに[JWT](https://tools.ietf.org/html/rfc7519)を発行します。
### 流れ
1. clientがemail/passをPOST
2. `#{remember_token}:#{user_id}`からJWTを作る
3. レスポンスボディとして`{auth_token: "jwt_string"}`が返る
4. リクエストヘッダに`Authorization: "Bearer jwt_string"`を付けたリクエストをclientが送る
5. serverはそれを見てOKなら`current_user`をセット。ダメなら401
