### PR TITLE
[WIP] JWTを使って認証するぞ

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,8 @@ gem 'carrierwave', '~> 0.10.0'
 gem 'mini_magick', '~> 4.2.7'
 gem 'fog', '~> 1.23'
 
+gem 'jwt', '~> 1.5'
+
 group :development, :test do
   # Use sqlite3 as the database for Active Record
   gem 'sqlite3', '~> 1.3.9'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -206,6 +206,7 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (1.8.3)
+    jwt (1.5.1)
     kgio (2.9.3)
     listen (2.10.1)
       celluloid (~> 0.16.0)
@@ -349,6 +350,7 @@ DEPENDENCIES
   i18n-debug (~> 1.0)
   jbuilder (~> 2.2)
   jquery-rails (~> 4.0.4)
+  jwt (~> 1.5)
   mini_backtrace (~> 0.1.3)
   mini_magick (~> 4.2.7)
   minitest-reporters (~> 1.0.5)
@@ -365,3 +367,6 @@ DEPENDENCIES
   web-console (~> 2.1)
   will-paginate-i18n (~> 0.1.15)
   will_paginate (~> 3.0.7)
+
+BUNDLED WITH
+   1.10.6

--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -3,14 +3,7 @@ class Api::ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :null_session
 
-  include SessionsHelper
-
-  # Confirms a logged-in user
-  def logged_in_user
-    unless logged_in?
-      render_errors ["Unauthorized"], status: :unauthorized
-    end
-  end
+  include Api::SessionsHelper
 
   def render_errors(error_messages, options)
     render options.merge(json: {"errors" => error_messages})

--- a/app/controllers/api/feed_controller.rb
+++ b/app/controllers/api/feed_controller.rb
@@ -1,5 +1,5 @@
 class Api::FeedController < Api::ApplicationController
-  before_action :logged_in_user, only: [:index]
+  before_action :set_current_user, only: [:index]
 
   def index
     render json: current_user.feed

--- a/app/controllers/api/microposts_controller.rb
+++ b/app/controllers/api/microposts_controller.rb
@@ -1,5 +1,5 @@
 class Api::MicropostsController < Api::ApplicationController
-  before_action :logged_in_user, only: [:create, :destroy]
+  before_action :set_current_user, only: [:create, :destroy]
   before_action :correct_user,   only: :destroy
 
   def create

--- a/app/controllers/api/password_resets_controller.rb
+++ b/app/controllers/api/password_resets_controller.rb
@@ -18,8 +18,7 @@ class Api::PasswordResetsController < Api::ApplicationController
     if params[:user][:password].blank?
       render_errors ["Password can't be blank"], status: :unprocessable_entity
     elsif @user.update(user_params)
-      log_in @user
-      render json: "", status: :accepted
+      render json: {auth_token: token_for(@user)}, status: :accepted
     else
       render_errors @user.errors.full_messages, status: :unprocessable_entity
     end

--- a/app/controllers/api/sessions_controller.rb
+++ b/app/controllers/api/sessions_controller.rb
@@ -1,13 +1,11 @@
 class Api::SessionsController < Api::ApplicationController
+  include Api::SessionsHelper
 
   def create
     @user = User.find_by(email: params[:session][:email].downcase)
     if @user && @user.authenticate(params[:session][:password])
       if @user.activated?
-        log_in @user
-        remember @user
-
-        render json: "", status: :created
+        render json: {auth_token: token_for(@user)}, status: :created
       else
         message = "Account not activated. Check your email for the activation link."
         render_errors [message], status: :forbidden
@@ -15,10 +13,5 @@ class Api::SessionsController < Api::ApplicationController
     else
       render_errors ["Invalid email or password"], status: :unauthorized
     end
-  end
-
-  def destroy
-    log_out if logged_in?
-    render json: "", status: :accepted
   end
 end

--- a/app/helpers/api/sessions_helper.rb
+++ b/app/helpers/api/sessions_helper.rb
@@ -1,0 +1,29 @@
+module Api::SessionsHelper
+  def set_current_user
+    begin
+      user_id = decode_token(request.headers["Authorization"])
+      @current_user = User.find(user_id)
+    rescue
+      render json: {errors: ["Unauthorized"]}, status: :unauthorized
+    end
+  end
+
+  def current_user
+    @current_user
+  end
+
+  def token_for(user)
+    "Bearer #{JWT.encode({user_id: user.id}, secret, 'HS256')}"
+  end
+
+  def decode_token(token)
+    token.sub!(/^Bearer\s+/, "")
+    JWT.decode(token, secret).first["user_id"]
+  end
+
+  private
+
+  def secret
+    Rails.application.secrets.secret_key_base
+  end
+end

--- a/test/controllers/api/feed_controller_test.rb
+++ b/test/controllers/api/feed_controller_test.rb
@@ -4,17 +4,18 @@ class Api::FeedControllerTest < ActionController::TestCase
 
   def setup
     @user = users(:michael)
+    @request.headers["Authorization"] = token_for(@user)
   end
 
   test 'should return micropost feed as json' do
-    log_in_as(@user)
-    get :index
+    get :index, {}
 
     assert_equal 200, response.status
     assert_equal @user.feed.to_json, response.body
   end
 
-  test 'should return 402 if user is not logged in' do
+  test 'should return 402 if auth token is missing' do
+    @request.headers["Authorization"] = ""
     get :index
 
     assert 402, response.status

--- a/test/controllers/api/microposts_controller_test.rb
+++ b/test/controllers/api/microposts_controller_test.rb
@@ -5,10 +5,10 @@ class Api::MicropostsControllerTest < ActionController::TestCase
   def setup
     @user = users(:michael)
     @micropost = microposts(:orange)
+    @request.headers["Authorization"] = token_for(@user)
   end
 
   test 'should return created micropost as json' do
-    log_in_as(@user)
     post :create, micropost: {content: "Lorem ipsum"}
 
     json = JSON.parse(response.body)
@@ -22,7 +22,6 @@ class Api::MicropostsControllerTest < ActionController::TestCase
   end
 
   test 'should return errors when params are invalid' do
-    log_in_as(@user)
     post :create, micropost: {content: ""}
 
     json = JSON.parse(response.body)
@@ -32,13 +31,14 @@ class Api::MicropostsControllerTest < ActionController::TestCase
   end
 
   test 'should return 202 when deleted the micropost' do
-    log_in_as(@user)
     delete :destroy, id: @micropost
 
     assert_equal 202, response.status
   end
 
-  test 'should return 401 if user was not logged in' do
+  test 'should return 401 if auth token is missing' do
+    @request.headers["Authorization"] = ""
+
     post :create, micropost: {content: "Lorem inpsum"}
 
     json = JSON.parse(response.body)
@@ -48,8 +48,8 @@ class Api::MicropostsControllerTest < ActionController::TestCase
   end
 
   test 'should return 403 if current_user is not the owner' do
-    other = users(:archer)
-    log_in_as(other)
+    @request.headers["Authorization"] = token_for(users :archer)
+
     delete :destroy, id: @micropost
 
     assert_equal 403, response.status

--- a/test/integration/api/password_resets_test.rb
+++ b/test/integration/api/password_resets_test.rb
@@ -59,7 +59,6 @@ class Api::PasswordResetsTest < ActionDispatch::IntegrationTest
     patch api_password_reset_path(user.reset_token),
           email: user.email,
           user: {password: 'foobar', password_confirmation: 'foobar'}
-    assert is_logged_in?, 'User should now be logged in'
     assert @user.reload.authenticate('foobar'), 'User should be able to login with the new password'
   end
 

--- a/test/integration/api/users_login_test.rb
+++ b/test/integration/api/users_login_test.rb
@@ -12,32 +12,13 @@ class Api::UserLoginTest < ActionDispatch::IntegrationTest
     assert_equal 401, response.status
   end
 
-  test 'login with valid information followed by logout' do
-    delete api_logout_path
+  test 'should return auth_token when givin information is valid' do
     post api_login_path, session: {email: @user.email, password: 'password'}
 
+    json = JSON.parse(response.body)
+
     assert_equal 201, response.status
-    assert_not_empty cookies["user_id"]
-    assert_not_empty cookies["remember_token"]
-
-    delete api_logout_path
-
-    assert_equal 202, response.status
-
-    assert_empty cookies["user_id"]
-    assert_empty cookies["remember_token"]
-  end
-
-  test 'logout twice affects nothing' do
-    delete api_logout_path
-
-    assert_equal 202, response.status
-    assert_not is_logged_in?
-
-    delete api_logout_path
-
-    assert_equal 202, response.status
-    assert_not is_logged_in?
+    assert_not_empty json["auth_token"]
   end
 
   test "token should be remembered regardless of the remember_me parameter" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,6 +18,7 @@ class ActiveSupport::TestCase
 
   # Add more helper methods to be used by all tests here...
   include ApplicationHelper
+  include Api::SessionsHelper
 
   # Returns true if a test user is logged in
   def is_logged_in?


### PR DESCRIPTION
### 概要

Web版ではcookieを読んで`current_user`をセットしていましたが、API版ではログイン時にトークンを渡して、以後のリクエストにそれを付けてもらうようにします。

`remember_token`を使おうという話をしていましたが、Web版でログアウトするとアプリ側もログアウトしてしまうので、却下となりました。

なのでトークンには`user_id`を使い、モダンに[JWT](https://tools.ietf.org/html/rfc7519)を発行します。
ペイロードが`{user_id: 3}`ってことです。
### 流れ
1. clientがemail/passをPOST
2. `user_id`からJWTを作る
3. レスポンスボディとして`{auth_token: "jwt_string"}`が返る
4. リクエストヘッダに`Authorization: "Bearer jwt_string"`を付けたリクエストをclientが送る
5. serverはそれを見てOKなら`current_user`をセット。ダメなら401
