### PR TITLE
メールのリンクを踏むとherokuへ飛ばされる問題

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -64,7 +64,7 @@ Rails.application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.delivery_method = :smtp
-  config.action_mailer.default_url_options = {host: 'agile-fjord-2695.herokuapp.com'}
+  config.action_mailer.default_url_options = {host: ENV['HOST_NAME']}
   ActionMailer::Base.smtp_settings = {
     address: ENV['SMTP_HOST'],
     port: ENV['SMTP_PORT'] || 587,


### PR DESCRIPTION
環境変数で指定できるようにします。

デプロイ時に指定することになります。
