### PR TITLE
/api/feedを修正

### DIFF
--- a/app/controllers/api/feed_controller.rb
+++ b/app/controllers/api/feed_controller.rb
@@ -2,6 +2,7 @@ class Api::FeedController < Api::ApplicationController
   before_action :set_current_user, only: [:index]
 
   def index
-    render json: current_user.feed
+    @microposts = current_user.feed
+    render template: "api/microposts/index"
   end
 end

--- a/app/views/api/microposts/_micropost.json.jbuilder
+++ b/app/views/api/microposts/_micropost.json.jbuilder
@@ -1,3 +1,3 @@
-json.extract!(micropost, :id, :user_id, :content, :created_at)
+json.extract!(micropost, :id, :user, :content, :created_at)
 
 json.picture_url(micropost.picture.url)

--- a/app/views/api/microposts/index.json.jbuilder
+++ b/app/views/api/microposts/index.json.jbuilder
@@ -1,0 +1,3 @@
+json.array! @microposts do |micropost|
+  json.partial! micropost
+end

--- a/test/controllers/api/feed_controller_test.rb
+++ b/test/controllers/api/feed_controller_test.rb
@@ -8,15 +8,23 @@ class Api::FeedControllerTest < ActionController::TestCase
   end
 
   test 'should return micropost feed as json' do
-    get :index, {}
+    get :index, format: :json
+
+    json = JSON.parse(response.body)
 
     assert_equal 200, response.status
-    assert_equal @user.feed.to_json, response.body
+
+    assert json.is_a?(Array)
+
+    expected_attrs = %w[id user content picture_url created_at].sort
+    json.each do |micropost|
+      assert_equal expected_attrs, micropost.keys.sort
+    end
   end
 
   test 'should return 402 if auth token is missing' do
     @request.headers["Authorization"] = ""
-    get :index
+    get :index, format: :json
 
     assert 402, response.status
   end


### PR DESCRIPTION
feed配列に含まれる個々のmicropostが、モデルをただ`to_json`しただけになっていたのを修正しました。
- `_micropost.json.jbuilder`パーシャルを使うようにしました。
- `user_id`属性を`user`に変更しました。
