### PR TITLE
micropost_countも返す

### DIFF
--- a/app/views/api/users/show.json.jbuilder
+++ b/app/views/api/users/show.json.jbuilder
@@ -2,6 +2,7 @@ json.extract!(@user, :id, :name, :avatar_url)
 
 json.followers_count(@user.followers.count)
 json.following_count(@user.following.count)
+json.micropost_count(@user.microposts.count)
 
 json.microposts do
   json.array!(@microposts) do |micropost|

--- a/test/integration/api/fetching_users_test.rb
+++ b/test/integration/api/fetching_users_test.rb
@@ -43,12 +43,13 @@ class Api::FetchingUsersTest < ActionDispatch::IntegrationTest
 
     assert json.is_a?(Hash)
 
-    expected_attrs = %w[id name avatar_url microposts following_count followers_count].sort
+    expected_attrs = %w[id name avatar_url microposts following_count followers_count micropost_count].sort
     assert_equal expected_attrs, json.keys.sort
 
-    assert_equal @user.avatar_url,      json["avatar_url"]
-    assert_equal @user.following.count, json["following_count"]
-    assert_equal @user.followers.count, json["followers_count"]
+    assert_equal @user.avatar_url,       json["avatar_url"]
+    assert_equal @user.following.count,  json["following_count"]
+    assert_equal @user.followers.count,  json["followers_count"]
+    assert_equal @user.microposts.count, json["micropost_count"]
   end
 
   test "each user's microposts should be paginated" do


### PR DESCRIPTION
`/api/users/me`, `/api/users/:id`をGETしたときに返るjsonに、`micropost_count`を含めるように変更しました。
