### PR TITLE
フォロー関係の取得

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -51,8 +51,8 @@ class Api::UsersController < Api::ApplicationController
   def follow_info
     if user = User.find(params[:id])
       info = {
-        following: @current_user.following?(user).to_s,
-        followed:  user.following?(@current_user).to_s
+        following: @current_user.following?(user),
+        followed:  user.following?(@current_user)
       }
       render json: info, status: :ok
     else

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -48,6 +48,18 @@ class Api::UsersController < Api::ApplicationController
     render action: :index
   end
 
+  def follow_info
+    if user = User.find(params[:id])
+      info = {
+        following: @current_user.following?(user).to_s,
+        followed:  user.following?(@current_user).to_s
+      }
+      render json: info, status: :ok
+    else
+      render_errors ["Not found"], status: not_found
+    end
+  end
+
   def follow
     user = User.find(params[:id])
     current_user.follow(user) unless current_user.following? user

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
     resources :users, except: [:new, :edit] do
       member do
         get :following, :followers
+        get    'follow' => 'users#follow_info'
         post   'follow' => 'users#follow'
         delete 'follow' => 'users#unfollow'
       end

--- a/test/integration/api/following_test.rb
+++ b/test/integration/api/following_test.rb
@@ -39,4 +39,44 @@ class Api::FollowingTest < ActionDispatch::IntegrationTest
 
     assert 401, response.status
   end
+
+  test "following information: michael follows archer" do
+    @user.follow @other
+    @other.unfollow @user
+    get follow_api_user_path(@other), {}, @headers
+
+    json = JSON.parse(response.body)
+
+    assert_equal "true",  json["following"]
+    assert_equal "false", json["followed"]
+  end
+
+  test "following information: archer follows michael" do
+    get follow_api_user_path(@other), {}, @headers
+
+    json = JSON.parse(response.body)
+
+    assert_equal "false", json["following"]
+    assert_equal "true",  json["followed"]
+  end
+
+  test "following information: following each other" do
+    @user.follow @other
+    get follow_api_user_path(@other), {}, @headers
+
+    json = JSON.parse(response.body)
+
+    assert_equal "true", json["following"]
+    assert_equal "true", json["followed"]
+  end
+
+  test "following information: not following each other" do
+    @other.unfollow @user
+    get follow_api_user_path(@other), {}, @headers
+
+    json = JSON.parse(response.body)
+
+    assert_equal "false", json["following"]
+    assert_equal "false", json["followed"]
+  end
 end

--- a/test/integration/api/following_test.rb
+++ b/test/integration/api/following_test.rb
@@ -47,8 +47,8 @@ class Api::FollowingTest < ActionDispatch::IntegrationTest
 
     json = JSON.parse(response.body)
 
-    assert_equal "true",  json["following"]
-    assert_equal "false", json["followed"]
+    assert     json["following"]
+    assert_not json["followed"]
   end
 
   test "following information: archer follows michael" do
@@ -56,8 +56,8 @@ class Api::FollowingTest < ActionDispatch::IntegrationTest
 
     json = JSON.parse(response.body)
 
-    assert_equal "false", json["following"]
-    assert_equal "true",  json["followed"]
+    assert_not json["following"]
+    assert     json["followed"]
   end
 
   test "following information: following each other" do
@@ -66,8 +66,8 @@ class Api::FollowingTest < ActionDispatch::IntegrationTest
 
     json = JSON.parse(response.body)
 
-    assert_equal "true", json["following"]
-    assert_equal "true", json["followed"]
+    assert json["following"]
+    assert json["followed"]
   end
 
   test "following information: not following each other" do
@@ -76,7 +76,7 @@ class Api::FollowingTest < ActionDispatch::IntegrationTest
 
     json = JSON.parse(response.body)
 
-    assert_equal "false", json["following"]
-    assert_equal "false", json["followed"]
+    assert_not json["following"]
+    assert_not json["followed"]
   end
 end


### PR DESCRIPTION
`/api/users/:id/follow`をGETすることでフォローしてるされてるの情報が取れるようになりました。

例えば、自分は相手(`:id`のユーザ)をフォローしてるけど、相手にはフォローされてない場合は

``` json
{
  "following": "true",
  "followed": "false"
}
```

っていうのが返ってきます。
