### PR TITLE
メール文中のURLもHTTPS対応

### DIFF
--- a/app/views/user_mailer/password_reset.html.erb
+++ b/app/views/user_mailer/password_reset.html.erb
@@ -2,7 +2,8 @@
 
 <p>To reset your password click the link below:</p>
 
-<%= link_to "Reset password", edit_password_reset_url(@user.reset_token, email: @user.email) %>
+<%= link_to "Reset password",
+            edit_password_reset_url(@user.reset_token, email: @user.email, protocol: "https") %>
 
 <p>This link will expire in two hours.</p>
 

--- a/app/views/user_mailer/password_reset.ja.html.erb
+++ b/app/views/user_mailer/password_reset.ja.html.erb
@@ -2,7 +2,8 @@
 
 <p>パスワードを再設定するには次のリンクをクリックしてください:</p>
 
-<%= link_to "パスワード再設定", edit_password_reset_url(@user.reset_token, email: @user.email) %>
+<%= link_to "パスワード再設定",
+            edit_password_reset_url(@user.reset_token, email: @user.email, protocol: "https") %>
 
 <p>このリンクは送信から2時間だけ利用可能です。</p>
 

--- a/app/views/user_mailer/password_reset.ja.text.erb
+++ b/app/views/user_mailer/password_reset.ja.text.erb
@@ -1,6 +1,6 @@
 パスワードを再設定するには次のリンクをクリックしてください:
 
-<%= edit_password_reset_url(@user.reset_token, email: @user.email) %>
+<%= edit_password_reset_url(@user.reset_token, email: @user.email, protocol: "https") %>
 
 このリンクは送信から2時間だけ利用可能です。
 

--- a/app/views/user_mailer/password_reset.text.erb
+++ b/app/views/user_mailer/password_reset.text.erb
@@ -1,6 +1,6 @@
 To reset your password click the link below:
 
-<%= edit_password_reset_url(@user.reset_token, email: @user.email) %>
+<%= edit_password_reset_url(@user.reset_token, email: @user.email, protocol: "https") %>
 
 This link will expire in two hours.
 

--- a/test/integration/api/password_resets_test.rb
+++ b/test/integration/api/password_resets_test.rb
@@ -15,6 +15,7 @@ class Api::PasswordResetsTest < ActionDispatch::IntegrationTest
     post api_password_resets_path, password_reset: {email: @user.email}
     assert_not_equal @user.reset_digest, @user.reload.reset_digest
     assert_equal 1, ActionMailer::Base.deliveries.size
+    assert_match /https:\/\//, ActionMailer::Base.deliveries.first.body.encoded
     assert_equal 201, response.status
   end
 

--- a/test/integration/password_resets_test.rb
+++ b/test/integration/password_resets_test.rb
@@ -19,6 +19,7 @@ class PasswordResetsTest < ActionDispatch::IntegrationTest
     post password_resets_path, password_reset: {email: @user.email}
     assert_not_equal @user.reset_digest, @user.reload.reset_digest
     assert_equal 1, ActionMailer::Base.deliveries.size
+    assert_match /https:\/\//, ActionMailer::Base.deliveries.first.body.encoded
     assert_not flash.empty?
     assert_redirected_to root_url
 


### PR DESCRIPTION
表題のとおりです。

ヘルパに`protocol: "https"`オプションを渡しています。
