### PR TITLE
認証トークンと一緒にユーザ情報を返す

### DIFF
--- a/app/controllers/api/account_activations_controller.rb
+++ b/app/controllers/api/account_activations_controller.rb
@@ -5,7 +5,7 @@ class Api::AccountActivationsController < Api::ApplicationController
     if @user && !(activated = @user.activated?) &&
         (authenticated = @user.authenticated?(:activation, params[:id]))
       @user.activate
-      render json: {auth_token: token_for(@user)}, status: :ok
+      render_authenticated @user, status: :ok
     else
       if !@user
         render_errors ["User not found"], status: :not_found

--- a/app/controllers/api/password_resets_controller.rb
+++ b/app/controllers/api/password_resets_controller.rb
@@ -18,7 +18,7 @@ class Api::PasswordResetsController < Api::ApplicationController
     if params[:user][:password].blank?
       render_errors ["Password can't be blank"], status: :unprocessable_entity
     elsif @user.update(user_params)
-      render json: {auth_token: token_for(@user)}, status: :accepted
+      render_authenticated @user, status: :accepted
     else
       render_errors @user.errors.full_messages, status: :unprocessable_entity
     end

--- a/app/controllers/api/sessions_controller.rb
+++ b/app/controllers/api/sessions_controller.rb
@@ -5,7 +5,7 @@ class Api::SessionsController < Api::ApplicationController
     @user = User.find_by(email: params[:session][:email].downcase)
     if @user && @user.authenticate(params[:session][:password])
       if @user.activated?
-        render json: {auth_token: token_for(@user)}, status: :created
+        render_authenticated @user, status: :created
       else
         message = "Account not activated. Check your email for the activation link."
         render_errors [message], status: :forbidden

--- a/app/helpers/api/sessions_helper.rb
+++ b/app/helpers/api/sessions_helper.rb
@@ -8,6 +8,13 @@ module Api::SessionsHelper
     end
   end
 
+  def render_authenticated(user, options)
+    render options.merge(
+      template: "api/shared/authenticated",
+      locals:   {token: token_for(user), user: user}
+    )
+  end
+
   def current_user
     @current_user
   end

--- a/app/views/api/shared/authenticated.json.jbuilder
+++ b/app/views/api/shared/authenticated.json.jbuilder
@@ -1,0 +1,4 @@
+json.auth_token token
+json.user do
+  json.partial! user
+end

--- a/test/integration/api/password_resets_test.rb
+++ b/test/integration/api/password_resets_test.rb
@@ -13,10 +13,21 @@ class Api::PasswordResetsTest < ActionDispatch::IntegrationTest
 
   test 'should return 201 when email was valid' do
     post api_password_resets_path, password_reset: {email: @user.email}
+
     assert_not_equal @user.reset_digest, @user.reload.reset_digest
     assert_equal 1, ActionMailer::Base.deliveries.size
     assert_match /https:\/\//, ActionMailer::Base.deliveries.first.body.encoded
     assert_equal 201, response.status
+
+    user = assigns(:user)
+
+    patch api_password_reset_path(user.reset_token),
+          email: user.email,
+          user:  {password: 'foobar', password_confirmation: 'foobar'}
+
+    json = JSON.parse(response.body)
+    assert_not_empty json["auth_token"]
+    assert_not_empty json["user"]
   end
 
   test 'should return 422 if user resets password with blank string' do

--- a/test/integration/api/users_login_test.rb
+++ b/test/integration/api/users_login_test.rb
@@ -19,6 +19,7 @@ class Api::UserLoginTest < ActionDispatch::IntegrationTest
 
     assert_equal 201, response.status
     assert_not_empty json["auth_token"]
+    assert_not_empty json["user"]
   end
 
   test "token should be remembered regardless of the remember_me parameter" do

--- a/test/integration/api/users_signup_test.rb
+++ b/test/integration/api/users_signup_test.rb
@@ -38,10 +38,15 @@ class Api::UsersSignupTest < ActionDispatch::IntegrationTest
 
     # Activate with valid token and correct email
     get edit_api_account_activation_path(user.activation_token, email: user.email)
+
+    json = JSON.parse(response.body)
+
     assert_equal 200, response.status
     assert user.reload.activated?
+    assert_not_empty json["auth_token"]
+    assert_not_empty json["user"]
 
-    # ALready activated
+    # Already activated
     get edit_api_account_activation_path(user.activation_token, email: user.email)
     assert_equal 422, response.status
   end


### PR DESCRIPTION
これまではトークンしか返していませんでしたが、クライアントが自分の情報を保持しやすいように、以下の形式のjsonが返るようにしました。

``` json
{
  "auth_token": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJ ...",
  "user": {
    "id": 1046959424,
    "name": "Example User",
    "avatar_url": "https://secure.gravatar.com/avatar/b58996c504c5638798eb6b511e6f49af"
  }
}
```
