### PR TITLE
carrier_waveのasset_hostを設定

### DIFF
--- a/app/controllers/api/feed_controller.rb
+++ b/app/controllers/api/feed_controller.rb
@@ -4,6 +4,6 @@ class Api::FeedController < Api::ApplicationController
   def index
     @microposts = current_user.feed.paginate(page: params[:page])
 
-    render template: "api/microposts/index", locals: {request: request}
+    render template: "api/microposts/index"
   end
 end

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -11,7 +11,7 @@ class Api::UsersController < Api::ApplicationController
   def show
     @microposts = @user.microposts.paginate(page: params[:page])
     unless @user.activated
-      render_errors ["Account not activated"], status: :forbidden, locals: {request: request}
+      render_errors ["Account not activated"], status: :forbidden
     end
   end
 

--- a/app/models/micropost.rb
+++ b/app/models/micropost.rb
@@ -8,10 +8,6 @@ class Micropost < ActiveRecord::Base
   validates :content, presence: true, length: { maximum: 140 }
   validate :picture_size
 
-  def full_picture_url(host)
-    URI.join("https://"+host, picture.url).to_s if picture.url
-  end
-
   private
 
   def picture_size

--- a/app/views/api/microposts/_micropost.json.jbuilder
+++ b/app/views/api/microposts/_micropost.json.jbuilder
@@ -1,6 +1,5 @@
-json.extract!(micropost, :id, :content, :created_at)
+json.extract!(micropost, :id, :content, :created_at, :picture_url)
 
 json.user do
   json.partial! micropost.user
 end
-json.picture_url(micropost.picture.url)

--- a/app/views/api/microposts/_micropost.json.jbuilder
+++ b/app/views/api/microposts/_micropost.json.jbuilder
@@ -3,4 +3,4 @@ json.extract!(micropost, :id, :content, :created_at)
 json.user do
   json.partial! micropost.user
 end
-json.picture_url(micropost.full_picture_url(request.host_with_port))
+json.picture_url(micropost.picture.url)

--- a/app/views/api/microposts/index.json.jbuilder
+++ b/app/views/api/microposts/index.json.jbuilder
@@ -1,3 +1,3 @@
 json.array! @microposts do |micropost|
-  json.partial! micropost, locals: {request: request}
+  json.partial! micropost
 end

--- a/app/views/api/users/show.json.jbuilder
+++ b/app/views/api/users/show.json.jbuilder
@@ -6,6 +6,6 @@ json.micropost_count(@user.microposts.count)
 
 json.microposts do
   json.array!(@microposts) do |micropost|
-    json.partial! micropost, locals: {request: request}
+    json.partial! micropost
   end
 end

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,0 +1,3 @@
+CarrierWave.configure do |config|
+  config.asset_host = "https://#{ENV['HOST_NAME']}"
+end

--- a/test/models/micropost_test.rb
+++ b/test/models/micropost_test.rb
@@ -32,8 +32,7 @@ class MicropostTest < ActiveSupport::TestCase
 
   test "picture_url" do
     micropost = microposts(:orange)
-    full_url = micropost.full_picture_url("localhost")
 
-    assert_equal "https://localhost"+micropost.picture.url, full_url
+    assert_match /^https:\/\//, micropost.picture_url
   end
 end


### PR DESCRIPTION
`micropost.picture_url`がフルなURLを返すようになりました
