### PR TITLE
adminをseedする

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,43 +1,47 @@
-begin
-  ActiveRecord::Base.transaction do
-    User.create!(name: 'Example User', email: 'example@railstutorial.org',
-                 password: 'foobar', password_confirmation: 'foobar',
-                 admin: true,
-                 activated: true, activated_at: Time.zone.now)
-
-    99.times do |n|
-      name  = Faker::Name.name
-      email = "example-#{n+1}@railstutorial.org"
-      password = 'password'
-      User.create!(name: name, email: email,
-                   password: password, password_confirmation: password,
+if Rails.env.development?
+  begin
+    ActiveRecord::Base.transaction do
+      User.create!(name: 'Example User', email: 'example@railstutorial.org',
+                   password: 'foobar', password_confirmation: 'foobar',
+                   admin: true,
                    activated: true, activated_at: Time.zone.now)
-    end
 
-
-    users = User.order(:created_at).take(6)
-    50.times do
-      users.each do |user|
-        user.microposts.create!(content: Faker::Lorem.sentence(5))
+      99.times do |n|
+        name  = Faker::Name.name
+        email = "example-#{n+1}@railstutorial.org"
+        password = 'password'
+        User.create!(name: name, email: email,
+                     password: password, password_confirmation: password,
+                     activated: true, activated_at: Time.zone.now)
       end
-    end
 
-    # Following relationships
-    users = User.all
-    user  = users.first
-    following = users[2..50]
-    followers = users[3..40]
-    following.each {|followed| user.follow(followed) }
-    followers.each {|follower| follower.follow(user) }
+
+      users = User.order(:created_at).take(6)
+      50.times do
+        users.each do |user|
+          user.microposts.create!(content: Faker::Lorem.sentence(5))
+        end
+      end
+
+      # Following relationships
+      users = User.all
+      user  = users.first
+      following = users[2..50]
+      followers = users[3..40]
+      following.each {|followed| user.follow(followed) }
+      followers.each {|follower| follower.follow(user) }
+    end
+  rescue => e
+    puts e
   end
-rescue => e
-  puts e
 end
 
-begin
-  ActiveRecord::Base.transaction do
-    AdminUser.create!(email: 'admin@example.com', password: 'password', password_confirmation: 'password')
+if Rails.env.development? || Rails.env.production?
+  begin
+    ActiveRecord::Base.transaction do
+      AdminUser.create!(email: 'admin@example.com', password: 'password', password_confirmation: 'password')
+    end
+  rescue => e
+    puts e
   end
-rescue => e
-  puts e
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -36,12 +36,7 @@ if Rails.env.development?
   end
 end
 
-if Rails.env.development? || Rails.env.production?
-  begin
-    ActiveRecord::Base.transaction do
-      AdminUser.create!(email: 'admin@example.com', password: 'password', password_confirmation: 'password')
-    end
-  rescue => e
-    puts e
-  end
+if (Rails.env.development? || Rails.env.production?) && (AdminUser.count == 0)
+  AdminUser.create(email: 'admin@example.com', password: 'password', password_confirmation: 'password')
 end
+


### PR DESCRIPTION
どうやらactiveadminの`AdminUser`は、謎テクノロジーで勝手に作られるわけでなはく、「seedに入れとくからよろしくねっ」っていうスタンスなようです。現状productionでは`db:seed`していないので、`/admin`以下にログインできません。

このPRは、インフラ側のコード変更と合わせて、railstutorial起動時に`db:seed`タスクが走るようにします。
