### PR TITLE
GET /api/stardomの返却するJSONにdateを入れる

### DIFF
--- a/app/controllers/api/stardom_controller.rb
+++ b/app/controllers/api/stardom_controller.rb
@@ -10,7 +10,7 @@ class Api::StardomController < Api::ApplicationController
       status = current_user.star_status || :stargazer
     end
 
-    render json: {active: active, star_status: status}
+    render json: {active: active, star_status: status, date: today}
   end
 
   def update

--- a/test/controllers/api/stardom_controller_test.rb
+++ b/test/controllers/api/stardom_controller_test.rb
@@ -27,6 +27,7 @@ class Api::StardomControllerTest < ActionController::TestCase
     assert_equal false, json['active']
     assert json.has_key?('star_status')
     assert_nil json['star_status']
+    assert_equal @now.to_date, json['date'].to_date
   end
 
   test 'when there are some stars' do
@@ -43,6 +44,7 @@ class Api::StardomControllerTest < ActionController::TestCase
     assert_equal true, json['active']
     assert json.has_key?('star_status')
     assert_equal 'stargazer', json['star_status']
+    assert_equal @now.to_date, json['date'].to_date
   end
 
   test 'when you are a candidate star' do
@@ -58,6 +60,7 @@ class Api::StardomControllerTest < ActionController::TestCase
 
     assert_equal true, json['active']
     assert_equal 'candidate', json['star_status']
+    assert_equal @now.to_date, json['date'].to_date
   end
 
   test 'when you are a star' do
@@ -73,6 +76,7 @@ class Api::StardomControllerTest < ActionController::TestCase
 
     assert_equal true, json['active']
     assert_equal 'accepted', json['star_status']
+    assert_equal @now.to_date, json['date'].to_date
   end
 
   test 'when you have declined to be a star' do
@@ -88,6 +92,7 @@ class Api::StardomControllerTest < ActionController::TestCase
 
     assert_equal true, json['active']
     assert_equal 'declined', json['star_status']
+    assert_equal @now.to_date, json['date'].to_date
   end
 
   test 'update should require authentication' do

--- a/test/controllers/api/stardom_controller_test.rb
+++ b/test/controllers/api/stardom_controller_test.rb
@@ -95,6 +95,22 @@ class Api::StardomControllerTest < ActionController::TestCase
     assert_equal @now.to_date, json['date'].to_date
   end
 
+  test 'paramter date should be shifted 3 hours' do
+    today = Date.new(1970, 6, 10)
+
+    @user.stars.create(date: today, status: :accepted)
+
+    travel_to(Time.zone.local(1970, 6, 11, 2, 59)) do
+      get :show, format: :json
+    end
+    assert_equal today, JSON.parse(response.body)['date'].to_date
+
+    travel_to(Time.zone.local(1970, 6, 11, 3, 0)) do
+      get :show, format: :json
+    end
+    assert_equal today+1, JSON.parse(response.body)['date'].to_date
+  end
+
   test 'update should require authentication' do
     @request.headers["Authorization"] = nil
     patch :update, format: :json


### PR DESCRIPTION
スター期間中の初回起動をAndroidアプリが判定するために、スター期間にユニークなIDを付与します。今回はIDとして日付を用います。
